### PR TITLE
fix: use StreamInterface::getSize to get the correct size of the body

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "psr/event-dispatcher": "^1.0",
         "psr/http-message": "^1.0",

--- a/src/Handler/PatchHandler.php
+++ b/src/Handler/PatchHandler.php
@@ -44,21 +44,8 @@ final class PatchHandler
             return $response->withStatus(415);
         }
 
-        set_error_handler(static function () {});
-        $body = fopen('php://temp', 'w+');
-        restore_error_handler();
-        Assert::resource($body);
-
-        $source = $request->getBody()->detach();
-        Assert::resource($source);
-
-        stream_copy_to_stream($source, $body);
-        rewind($body);
-
-        $stat = fstat($body);
-        Assert::isArray($stat);
-
-        $size = $stat['size'];
+        $size = $request->getBody()->getSize();
+        $body = $request->getBody();
 
         $clientOffset = (int) $request->getHeaderLine('Upload-Offset');
 
@@ -79,8 +66,6 @@ final class PatchHandler
             }
         } catch (FileNotFound $e) {
             return $response->withStatus(404);
-        } finally {
-            fclose($body);
         }
 
         if ($newOffset !== ($clientOffset + $size)) {


### PR DESCRIPTION
In my setup, using Minio as the S3 backend, the append method in the storage receive everytime an empty body. The proposed fix only use StreamInterface API to get the size and directly pass the body to the storage append command.